### PR TITLE
fix: use latest `near-social-vm` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-config-next": "13.3.4",
     "firebase": "^9.19.1",
     "near-api-js": "2.1.3",
-    "near-social-vm": "github:NearSocial/VM#2.2.3",
+    "near-social-vm": "github:NearSocial/VM#2.4.2",
     "next": "13.3.4",
     "prettier": "^2.7.1",
     "react": "18.2.0",


### PR DESCRIPTION
The current `near-social-vm` version lacks support for symbols such as `useEffect` and `useState`, that are crucial in `BOS` development. Since this example is used as an entry-point, updating the dependency makes most sense and avoid newcomers desisting because of easily-fixable complications.